### PR TITLE
Configuration Safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ release :my_release do
   set(
     # Use the EnvVar provider to handle config overrides
     config_providers: [
-      {EnvVar.Provider, [prefix: "my_release", env_map: env_config]}
+      {EnvVar.Provider, [prefix: "my_release", env_map: env_config, enforce: false]}
     ]
   )
 end
@@ -124,3 +124,11 @@ You have two choices when dealing with default values:
 
 If you supply default values, they will overwrite any existing values in the
 config for this environment.
+
+### Enforcement
+
+For further safety, you may set `enforce: true` in the Keyword list to
+configure the provider. This behavior is the equivalent of setting `required:
+true` on each of the items. This prevents the provider from ever falling back
+to values in the configuration. This is the safest way to guarantee that a
+value, either in the environment, or a default, was set.

--- a/lib/mix/tasks/show_vars.ex
+++ b/lib/mix/tasks/show_vars.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.ShowVars do
   end
 
   def run(args) do
+    Mix.Task.run("compile")
     if Code.ensure_compiled?(EnvVar.Config) do
       [prefix] = args
       config = EnvVar.Config.config()

--- a/lib/providers/env_var_provider.ex
+++ b/lib/providers/env_var_provider.ex
@@ -119,7 +119,7 @@ defmodule EnvVar.Provider do
   defp get_env_value(key, config) do
     key
     |> System.get_env()
-    |> set_default(config[:default])
+    |> set_default(config[:default], key)
     |> convert(config[:type])
   end
 
@@ -188,11 +188,12 @@ defmodule EnvVar.Provider do
     |> Enum.map(&convert(&1, type))
   end
 
-  defp set_default(value, default) when is_nil(value) do
+  defp set_default(value, default, env_var_name) when is_nil(value) do
+    Logger.warn("Using default value for #{env_var_name}")
     default
   end
 
-  defp set_default(value, default) do
+  defp set_default(value, default, _env_var_name) do
     if String.length(value) < 1 do
       default
     else

--- a/lib/providers/env_var_provider.ex
+++ b/lib/providers/env_var_provider.ex
@@ -126,7 +126,7 @@ defmodule EnvVar.Provider do
   # Make sure we have a value set of some kind, and then either
   # log an error, or abort if we're configured to do that.
   defp validate(value, _app, _key, env_var_name, enforce) do
-    if enforce do
+    if (is_nil(value) || value == "") && enforce do
       raise RuntimeError, message: "Config enforcement on and missing value for #{env_var_name} so crashing"
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EnvVarProvider.MixProject do
   def project do
     [
       app: :env_var_provider,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/env_var_provider_test.exs
+++ b/test/env_var_provider_test.exs
@@ -157,13 +157,26 @@ defmodule EnvVar.ProviderTest do
   end
 
   describe "when handling enforcement" do
-    test "requires everything when enforce is true", state do
-      System.put_env("BEOWULF_MYCLUSTER_SERVER_COUNT", "67")
-      System.put_env("BEOWULF_MYCLUSTER_NAME", "hrothgar")
-      
+    test "requires everything when enforce is true and there are no defaults" do
+      env_map = %{
+        the_system: %{
+          service_name: %{type: :string}
+        }
+      }
       assert_raise(RuntimeError, fn -> 
-        EnvVar.Provider.init(prefix: "beowulf", env_map: state[:simple], enforce: true)
+        EnvVar.Provider.init(prefix: "beowulf", env_map: env_map, enforce: true)
       end)
+    end
+
+    test "does not raise when defaults are present" do
+      env_map = %{
+        the_system: %{
+          service_name: %{type: :string, default: "beowulf"}
+        }
+      }
+      
+      # Should not raise
+      EnvVar.Provider.init(prefix: "beowulf", env_map: env_map, enforce: true)
     end
   end
 end

--- a/test/env_var_provider_test.exs
+++ b/test/env_var_provider_test.exs
@@ -1,5 +1,6 @@
 defmodule EnvVar.ProviderTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
 
   doctest EnvVar.Provider
 
@@ -67,6 +68,7 @@ defmodule EnvVar.ProviderTest do
   end
 
   describe "when the value is a Keyword list" do
+    @tag capture_log: true
     test "it correctly defaults values for numbers, strings, lists, tuples", state do
       EnvVar.Provider.init(prefix: "beowulf", env_map: state[:complex], enforce: false)
 
@@ -77,6 +79,7 @@ defmodule EnvVar.ProviderTest do
       assert Keyword.get(conf, :list_key) == [1, 2, 3]
     end
 
+    @tag capture_log: true
     test "it pulls in the right env var values", state do
       System.put_env("BEOWULF_MYCLUSTER_CLUSTER_OPTIONS_CREDENTIALS", "myuser,mypass")
       System.put_env("BEOWULF_MYCLUSTER_CLUSTER_OPTIONS_PORT", "11121")
@@ -92,6 +95,7 @@ defmodule EnvVar.ProviderTest do
   end
 
   describe "when dealing with simple values" do
+    @tag capture_log: true
     test "it handles empty prefix", state do
       System.put_env("MYCLUSTER_SERVER_COUNT", "67")
       EnvVar.Provider.init(prefix: "", env_map: state[:simple], enforce: false)
@@ -99,6 +103,7 @@ defmodule EnvVar.ProviderTest do
       assert Application.get_env(:mycluster, :server_count) == 67
     end
 
+    @tag capture_log: true
     test "it correctly defaults values for numbers, strings, lists, tuples", state do
       EnvVar.Provider.init(prefix: "beowulf", env_map: state[:simple], enforce: false)
 
@@ -108,6 +113,7 @@ defmodule EnvVar.ProviderTest do
       assert Application.get_env(:mycluster, :keys) == {1.1, 2.3, 3.4}
     end
 
+    @tag capture_log: true
     test "it pulls in the right env var values", state do
       System.put_env("BEOWULF_MYCLUSTER_SERVER_COUNT", "67")
       System.put_env("BEOWULF_MYCLUSTER_NAME", "hrothgar")
@@ -121,6 +127,7 @@ defmodule EnvVar.ProviderTest do
       assert Application.get_env(:mycluster, :keys) == {3.2, 5.6, 7.8}
     end
 
+    @tag capture_log: true
     test "creates new values with defaults that didn't already exist", state do
       EnvVar.Provider.init(prefix: "beowulf", env_map: state[:simple], enforce: false)
 
@@ -129,6 +136,7 @@ defmodule EnvVar.ProviderTest do
   end
 
   describe "when dealing with Elixir module atom keys" do
+    @tag capture_log: true
     test "it handles Elixir modules as keys cleanly", state do
       System.put_env("BEOWULF_APP_ENVVAR_PROVIDER", "different")
 
@@ -139,6 +147,7 @@ defmodule EnvVar.ProviderTest do
   end
 
   describe "when there is no default value" do
+    @tag capture_log: true
     test "it defaults to what is in the config already", state do
       Application.put_env(:app, EnvVar.Provider, "original")
       map = state[:elixir_mod]
@@ -151,12 +160,14 @@ defmodule EnvVar.ProviderTest do
   end
 
   describe "handling conditions that only occur in a release" do
+    @tag capture_log: true
     test "convert can handle nil" do
       EnvVar.Provider.convert(nil, :integer)
     end
   end
 
   describe "when handling enforcement" do
+    @tag capture_log: true
     test "requires everything when enforce is true and there are no defaults" do
       env_map = %{
         the_system: %{
@@ -168,7 +179,7 @@ defmodule EnvVar.ProviderTest do
       end)
     end
 
-    test "does not raise when defaults are present" do
+    test "does not raise when defaults are present and keys are missing" do
       env_map = %{
         the_system: %{
           service_name: %{type: :string, default: "beowulf"}
@@ -176,7 +187,11 @@ defmodule EnvVar.ProviderTest do
       }
       
       # Should not raise
-      EnvVar.Provider.init(prefix: "beowulf", env_map: env_map, enforce: true)
+      logs = capture_log(fn ->
+        EnvVar.Provider.init(prefix: "beowulf", env_map: env_map, enforce: true)
+      end)
+
+      assert String.contains?(logs, "default value for BEOWULF_THE_SYSTEM_SERVICE_NAME")
     end
   end
 end


### PR DESCRIPTION
It's too easy to end up running the application with no defaults set and dropping through to the config, only to end up running with an incorrect setting. This PR adds an option to force all fields to be required if they don't have a value set either through the environment or from a default.

This _also_ fixes the issue with the `show_vars` mix task not working for most projects. This was because there was no forced compilation before running the task and the `EnvVar.Config` module was usually not defined in the scope mix was running in.