### PR TITLE
Update Distillery to ~> 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os: linux
 dist: xenial
 
 elixir:
-  - 1.8.1
+  - 1.9.4
 
 otp_release:
   - 21.2

--- a/lib/providers/env_var_provider.ex
+++ b/lib/providers/env_var_provider.ex
@@ -5,7 +5,7 @@ defmodule EnvVar.Provider do
   system environment variables. These variable names are constructed
   from the field names directly, following a convention.
   """
-  use Mix.Releases.Config.Provider
+  use Distillery.Releases.Config.Provider
 
   @doc """
   init is called by Distillery when running the provider during boostrap.

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule EnvVarProvider.MixProject do
 
   defp deps do
     [
-      {:distillery, "~> 2.0.0"},
+      {:distillery, "~> 2.1.0"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule EnvVarProvider.MixProject do
   def project do
     [
       app: :env_var_provider,
-      version: "0.4.1",
-      elixir: "~> 1.7",
+      version: "0.4.2",
+      elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "artificery": {:hex, :artificery, "0.2.6", "f602909757263f7897130cbd006b0e40514a541b148d366ad65b89236b93497a", [:mix], [], "hexpm"},
-  "distillery": {:hex, :distillery, "2.0.12", "6e78fe042df82610ac3fa50bd7d2d8190ad287d120d3cd1682d83a44e8b34dfb", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
+  "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm"},
+  "distillery": {:hex, :distillery, "2.1.1", "f9332afc2eec8a1a2b86f22429e068ef35f84a93ea1718265e740d90dd367814", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.1", "88eaa16e67c505664fd6a66f42ddb962d424ad68df586b214b71443c69887123", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This will make env_var_provider work on Elixir 1.9.