### PR TITLE
172354803: Add support for boolean env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Supported types:
  * `:string`
  * `:integer`
  * `:float`
+ * `:boolean` - 0, 1, 'true', 'false' supported
  * `{:tuple, <type>}` - Complex type, where the second field is
    one of the simple types above. Currently items in the tuple
    must all be of the same type. A 3rd argument can be passed

--- a/lib/providers/env_var_provider.ex
+++ b/lib/providers/env_var_provider.ex
@@ -73,7 +73,7 @@ defmodule EnvVar.Provider do
 
   The supported types are:
 
-    * simple types - `:string`, `:integer`, or `:float`
+    * simple types - `:string`, `:integer`, `:float`, or `:boolean`
 
     * `{:tuple, TYPE, SEPARATOR}` - complex type where the second field
     is one of the simple types above. `SEPARATOR` is used as the separator.
@@ -82,6 +82,13 @@ defmodule EnvVar.Provider do
 
     * `{:list, TYPE, SEPARATOR}` and `{:list, TYPE}` - complex type that
       behaves like `{:tuple, ...}` but parsing to a list.
+
+  A note on `boolean` types. The following are supported syntax:
+
+    * "true"
+    * "1" -> true
+    * "false"
+    * "0" -> false
 
   ## Variable name convention
 
@@ -221,6 +228,16 @@ defmodule EnvVar.Provider do
 
   def convert(env_value, :string) do
     env_value
+  end
+
+  def convert(env_value, :boolean) do
+    case env_value do
+      "1" -> true
+      "0" -> false
+      "true" -> true
+      "false" -> false
+      _other -> raise ArgumentError, "expected boolean ('0', '1', 'true', 'false'), got: #{inspect(env_value)}"
+    end
   end
 
   def convert(env_value, {:tuple, type}) do

--- a/test/env_var_provider_test.exs
+++ b/test/env_var_provider_test.exs
@@ -231,6 +231,7 @@ defmodule EnvVar.ProviderTest do
       end
 
       System.put_env("BEOWULF_THE_SYSTEM_FEATURE_FLAG_ENABLED", "not a boolean")
+
       assert_raise ArgumentError, ~r/expected boolean/, fn ->
         init_and_load([], prefix: "beowulf", env_map: state[:simple], enforce: false)
       end


### PR DESCRIPTION
This adds support for booleans as a simple type. Because all the complex types are made up of the simple types, this will be supported in maps and lists as well.

cc @JoeMerriweather-Webb @tehprofessor 