### PR TITLE
Fix overlapping property and name use-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
 
+## [0.5.3] - 2021-02-01
+  - Fixes bug related to the edgecase where `TYPE` is in the environment variable
+    name. For example: Environment variable `SOMETHING_TYPE` should be readable
+    using the map `%{something: %{type: %{type: :string}}}`.
+
 ## [0.5.2] - 2020-06-18
   - Ensures project is compiled before the mix `show_vars` task runs.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `env_var_provider` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:env_var_provider, "~> 0.5.2", organization: "community"}
+    {:env_var_provider, "~> 0.5.3", organization: "community"}
   ]
 end
 ```

--- a/lib/providers/env_var_provider.ex
+++ b/lib/providers/env_var_provider.ex
@@ -170,13 +170,7 @@ defmodule EnvVar.Provider do
   end
 
   defp process_and_merge_config(prefix, enforce, app, key, key_config) do
-    case key_config do
-      %{type: _} ->
-        parse_config(prefix, enforce, [app, key], key_config)
-
-      _other ->
-        parse_config(prefix, enforce, [app, key], key_config)
-    end
+    parse_config(prefix, enforce, [app, key], key_config)
   end
 
   defp parse_config(prefix, enforce, path, %{type: type_value} = schema)

--- a/lib/providers/env_var_provider.ex
+++ b/lib/providers/env_var_provider.ex
@@ -179,7 +179,8 @@ defmodule EnvVar.Provider do
     end
   end
 
-  defp parse_config(prefix, enforce, path, %{type: _} = schema) do
+  defp parse_config(prefix, enforce, path, %{type: type_value} = schema)
+       when not is_map(type_value) do
     env_var_name = lookup_key_for([prefix | path])
 
     env_var_name

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EnvVarProvider.MixProject do
   def project do
     [
       app: :env_var_provider,
-      version: "0.5.2",
+      version: "0.5.3",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
__NOTE: Not sure how important this is, but this is the only repo I had access to so thought I'd address this use case__

This is for the case when an environment variable has overlapping name with one of the expected schema properties. 

For example:
`LOGGER_TYPE` could be read as `%{logger: %{type: %{type: :string}}}`

This wasn't working earlier, so I updated `EnvVarProvider.parse_config/4` to make this work.

_I also removed a redundant match in the module_